### PR TITLE
Fix extension settings crash

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -229,7 +229,6 @@ var SettingsPage = new Lang.Class({
 
         // add the frames
         this.add(userFrame);
-        this.add(calendarFrame);
         this.add(powerFrame);
     }
 });


### PR DESCRIPTION
Undefined calendarFrame variable (removed by https://github.com/TheBlackKoala/panel-indicators/commit/71904d722bf05e3a9e2c84a3303ac9d2e5a29450) 